### PR TITLE
Fixes the imports so that compile-time DI works

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,5 +1,5 @@
-import play.api._
 import play.api.ApplicationLoader.Context
+import play.api.{ApplicationLoader, BuiltInComponentsFromContext}
 import play.filters.HttpFiltersComponents
 import router.Routes
 


### PR DESCRIPTION
Removing the wildcard import and following the import errors resolves the issue, as shown in this PR.

It isn't obvious that this is the solution. Following the compile errors given by the documented approach leads to a deep and confusing rabbit hole of incompatible imports.

The main area of trouble is the controllers package. There are at least three of these! The application controller is in the controllers package in this application, the AssetsComponents mixin comes from another, and an incompatible AssetsComponents is available under play.controllers. The last of these is how IntelliJ tries to fix the problem, which leads to another rabbit hole of discovering why there are incompatible members in the class (see below - this error is a DevX disaster even for an experienced Scala / Play user).

```
[error] override def configuration: play.api.Configuration (defined in trait ContextBasedBuiltInComponents)
[error]   with <defaultmethod> def configuration(): play.api.Configuration (defined in trait ConfigurationComponents);
[error]  other members with override errors are: environment, applicationLifecycle, httpErrorHandler, fileMimeTypes
[error] class MyComponents(context: Context)
```
